### PR TITLE
Errors responses did not get a Cors Header

### DIFF
--- a/jax-rs-extractor/pom.xml
+++ b/jax-rs-extractor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>se.simonsoft.lambadaframework</groupId>
         <artifactId>lambada</artifactId>
-        <version>0.8.5</version>
+        <version>0.8.6</version>
     </parent>
     <artifactId>jax-rs-extractor</artifactId>
     <packaging>jar</packaging>

--- a/lambada-maven-plugin/pom.xml
+++ b/lambada-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>se.simonsoft.lambadaframework</groupId>
         <artifactId>lambada</artifactId>
-        <version>0.8.5</version>
+        <version>0.8.6</version>
     </parent>
 
     <artifactId>lambada-maven-plugin</artifactId>

--- a/logger/pom.xml
+++ b/logger/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambada</artifactId>
         <groupId>se.simonsoft.lambadaframework</groupId>
-        <version>0.8.5</version>
+        <version>0.8.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Log support</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>se.simonsoft.lambadaframework</groupId>
     <artifactId>lambada</artifactId>
-    <version>0.8.5</version>
+    <version>0.8.6</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>se.simonsoft.lambadaframework</groupId>
         <artifactId>lambada</artifactId>
-        <version>0.8.5</version>
+        <version>0.8.6</version>
     </parent>
     <artifactId>runtime</artifactId>
     <packaging>jar</packaging>

--- a/runtime/src/main/java/org/lambadaframework/runtime/errorhandling/ErrorHandler.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/errorhandling/ErrorHandler.java
@@ -23,7 +23,7 @@ public class ErrorHandler {
         } catch (InvocationTargetException ex) {
             return new BadRequestResponse();
         } catch (NotFoundException ex) {
-            return new NotFoundErrorResponse("Page not found");
+            return new NotFoundErrorResponse();
         } catch (Exception ex) {
             return new ErrorResponse();
         } finally {

--- a/runtime/src/main/java/org/lambadaframework/runtime/models/ResponseProxy.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/models/ResponseProxy.java
@@ -21,7 +21,7 @@ public class ResponseProxy implements Serializable {
     /**
      * Response headers
      */
-    protected Map<String, String> headers;
+    protected Map<String, String> headers = new LinkedHashMap<>();
 
     /**
      * Status code
@@ -32,6 +32,16 @@ public class ResponseProxy implements Serializable {
      * Response entity
      */
     protected Object entity;
+
+    public ResponseProxy() {
+    }
+
+    public ResponseProxy(int code, Object entity) {
+        this.code = code;
+        this.entity = entity;
+        setCors();
+    }
+
 
     public static ResponseProxy buildFromJAXRSResponse(Object response) throws RuntimeException, IOException {
 
@@ -45,7 +55,6 @@ public class ResponseProxy implements Serializable {
 
             outputResponse.entity = JAXResponse.getEntity();
             outputResponse.code = status;
-            outputResponse.headers = new LinkedHashMap<>();
             outputResponse.setCors();
 
             for (Map.Entry<String, List<Object>> entry : JAXResponse.getHeaders().entrySet()) {

--- a/runtime/src/main/java/org/lambadaframework/runtime/models/error/BadRequestResponse.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/models/error/BadRequestResponse.java
@@ -5,12 +5,6 @@ public class BadRequestResponse extends ErrorResponse {
 
 
     public BadRequestResponse() {
-        this.entity = "Bad request";
-        this.code = 400;
-    }
-
-    public BadRequestResponse(String errorMessage) {
-        this();
-        this.entity = errorMessage;
+        super(400, "Bad request");
     }
 }

--- a/runtime/src/main/java/org/lambadaframework/runtime/models/error/ErrorResponse.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/models/error/ErrorResponse.java
@@ -9,13 +9,12 @@ public class ErrorResponse extends ResponseProxy {
 
     protected String errorMessage;
 
+
     public ErrorResponse() {
-        this.entity = "Internal Server Error";
-        this.code = 500;
+        super(500, "Internal Server Error");
     }
 
-    public ErrorResponse(String errorMessage) {
-        this();
-        this.entity = errorMessage;
+    public ErrorResponse(int code, Object entity) {
+        super(code, entity);
     }
 }

--- a/runtime/src/main/java/org/lambadaframework/runtime/models/error/NotFoundErrorResponse.java
+++ b/runtime/src/main/java/org/lambadaframework/runtime/models/error/NotFoundErrorResponse.java
@@ -7,12 +7,6 @@ public class NotFoundErrorResponse extends ErrorResponse {
     protected String errorMessage;
 
     public NotFoundErrorResponse() {
-        this.entity = "Page not found";
-        this.code = 404;
-    }
-
-    public NotFoundErrorResponse(String errorMessage) {
-        this();
-        this.entity = errorMessage;
+        super(404, "Page not found");
     }
 }

--- a/stub-handlers/pom.xml
+++ b/stub-handlers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambada</artifactId>
         <groupId>se.simonsoft.lambadaframework</groupId>
-        <version>0.8.5</version>
+        <version>0.8.6</version>
     </parent>
     <name>Stub Handlers for Tests</name>
     <modelVersion>4.0.0</modelVersion>

--- a/wagon/pom.xml
+++ b/wagon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambada</artifactId>
         <groupId>se.simonsoft.lambadaframework</groupId>
-        <version>0.8.5</version>
+        <version>0.8.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>S3 Wagon</name>


### PR DESCRIPTION
Added constructors, instead of setting code and entity message we use
the super constructor. ResponseProxy will set cors for all responses.